### PR TITLE
Fix key collision in revenue by application chart

### DIFF
--- a/OSX/AppWage/UI/Tabs/Dashboard/AWCountryChart.m
+++ b/OSX/AppWage/UI/Tabs/Dashboard/AWCountryChart.m
@@ -140,7 +140,13 @@
                 NSArray * products = [AWProduct allProducts];
                 [products enumerateObjectsUsingBlock:
                  ^(AWProduct * product, NSUInteger index, BOOL * stop) {
-                    lookup[product.appleIdentifier] = product.title;
+                    BOOL productHasDuplicateTitle = [lookup.allValues containsObject:product.title];
+                    if (productHasDuplicateTitle) {
+                        lookup[product.appleIdentifier] = [NSString stringWithFormat:@"%@ (%@)", product.title, product.appleIdentifier];
+                    }
+                    else {
+                        lookup[product.appleIdentifier] = product.title;
+                    }
                 }];
                 break;
             }


### PR DESCRIPTION
Product titles are used as keys in the groupValues dictionary.
If you have two or more products with the same title, one revenue
number would overwrite another and result in an incorrect chart.
Circumvent this by appending the product id to the product title in
case of duplicate titles.

(thanks for sharing this app, very useful!)