### PR TITLE
Use correct currency symbol

### DIFF
--- a/OSX/AppWage/Business/AWCurrencyHelper.h
+++ b/OSX/AppWage/Business/AWCurrencyHelper.h
@@ -23,4 +23,6 @@
 
 @property(nonatomic,retain) NSArray * allCurrencies;
 
+@property(nonatomic,readonly) NSString * currentCurrencySymbol;
+
 @end

--- a/OSX/AppWage/Business/AWCurrencyHelper.m
+++ b/OSX/AppWage/Business/AWCurrencyHelper.m
@@ -11,12 +11,6 @@
 
 #define kExchangeRateUserDefault            @"ExchangeRates"
 
-@interface AWCurrencyHelper()
-{
-    NSDictionary * currencyDictionary;
-}
-@end
-
 @implementation AWCurrencyHelper
 
 @synthesize allCurrencies;
@@ -42,10 +36,9 @@
 
         NSData * currencyData = [NSData dataWithContentsOfFile: currencyPath];
 
-        NSError __autoreleasing * error = nil;
         NSDictionary * currencyArray = [NSJSONSerialization JSONObjectWithData: currencyData
                                                                   options: kNilOptions
-                                                                    error: &error];
+                                                                    error: NULL];
         
         NSMutableArray * _allCurrencies = [NSMutableArray array];
         [currencyArray enumerateKeysAndObjectsUsingBlock: ^(NSString * key, NSString * value, BOOL * stop)
@@ -61,7 +54,7 @@
                                                                    ascending: YES];
 
         // Set our currencies
-        allCurrencies = [NSArray arrayWithArray: [_allCurrencies sortedArrayUsingDescriptors: @[descriptor]]];
+        allCurrencies = [_allCurrencies sortedArrayUsingDescriptors: @[descriptor]];
     }
 
     return self;
@@ -149,6 +142,25 @@
     [currencyCase appendString: @"ELSE 0\r\n"];
 
     return currencyCase.copy;
+}
+
+- (NSString *)currentCurrencySymbol
+{
+    NSString *currencyCode = [AWSystemSettings sharedInstance].currencyCode;
+    
+    NSNumberFormatter *numberFormatter = [NSNumberFormatter new];
+    numberFormatter.numberStyle = NSNumberFormatterCurrencyStyle;
+    
+    for (NSString *identifier in [NSLocale availableLocaleIdentifiers]) {
+        NSLocale *locale = [NSLocale localeWithLocaleIdentifier:identifier];
+        if ([locale.currencyCode isEqual:currencyCode]) {
+            numberFormatter.locale = locale;
+            return numberFormatter.currencySymbol;
+        }
+    }
+    
+    // Return a fallback in case we can't find anything - shouldn't happen.
+    return @"$";
 }
 
 @end

--- a/OSX/AppWage/Business/Email/AWEmailHelper.m
+++ b/OSX/AppWage/Business/Email/AWEmailHelper.m
@@ -160,6 +160,9 @@
              dailyEmail: (BOOL) dailyEmail
           finishedBlock: (void (^)(NSError * error)) onFinished;
 {
+    // Update the currency symbol to what is currently configured before formatting any numbers.
+    currencyFormatter.currencySymbol = [AWCurrencyHelper sharedInstance].currentCurrencySymbol;
+    
     // Get yesterdayDate
     NSDateComponents * dateComponents = [[NSCalendar currentCalendar] components:NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear | NSCalendarUnitDay
                                                                         fromDate: [NSDate date]];

--- a/OSX/AppWage/UI/Dialogs/SystemPreferences/AWPreferencesWindowController.m
+++ b/OSX/AppWage/UI/Dialogs/SystemPreferences/AWPreferencesWindowController.m
@@ -449,31 +449,27 @@ static NSDictionary * localizedEntries;
 
 - (IBAction) onAccept: (id) sender
 {
-    dispatch_async(dispatch_get_global_queue(0, 0), ^{
-        if([self updateDetails])
-        {
-            // Update the network settings
-            [self updateNetworkSettings];
+    if([self updateDetails])
+    {
+        // Update the network settings
+        [self updateNetworkSettings];
 
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [[NSNotificationCenter defaultCenter] postNotificationName: [AWApplicationListTreeViewController applicationListRequiresUpdateNotificationName]
-                                                                    object: nil];
-                
-                // Post a review and rank update
-                [[NSNotificationCenter defaultCenter] postNotificationName: [AWCollectionOperationQueue newReviewsNotificationName]
-                                                                    object: nil];
-                
-                [[NSNotificationCenter defaultCenter] postNotificationName: [AWCollectionOperationQueue newReportsNotificationName]
-                                                                    object: nil];
-                
-                [[NSNotificationCenter defaultCenter] postNotificationName: [AWCollectionOperationQueue newRanksNotificationName]
-                                                                    object: nil];
+        [[NSNotificationCenter defaultCenter] postNotificationName: [AWApplicationListTreeViewController applicationListRequiresUpdateNotificationName]
+                                                            object: nil];
+        
+        // Post a review and rank update
+        [[NSNotificationCenter defaultCenter] postNotificationName: [AWCollectionOperationQueue newReviewsNotificationName]
+                                                            object: nil];
+        
+        [[NSNotificationCenter defaultCenter] postNotificationName: [AWCollectionOperationQueue newReportsNotificationName]
+                                                            object: nil];
+        
+        [[NSNotificationCenter defaultCenter] postNotificationName: [AWCollectionOperationQueue newRanksNotificationName]
+                                                            object: nil];
 
-                // Close our sheet.
-                [self endSheetWithReturnCode: NSModalResponseOK];
-            });
-        } // End of updateDetails
-    });
+        // Close our sheet.
+        [self endSheetWithReturnCode: NSModalResponseOK];
+    } // End of updateDetails
 }
 
 - (void) updateNetworkSettings

--- a/OSX/AppWage/UI/Tabs/Dashboard/AWCountryChart.m
+++ b/OSX/AppWage/UI/Tabs/Dashboard/AWCountryChart.m
@@ -83,6 +83,9 @@
         return;
     }
 
+    // Update the currency symbol to what is currently configured before formatting any numbers.
+    currencyFormatter.currencySymbol = [AWCurrencyHelper sharedInstance].currentCurrencySymbol;
+
     dispatch_async(dispatch_get_global_queue(0, 0), ^{
         MachTimer * machTimer = [MachTimer startTimer];
 

--- a/OSX/AppWage/UI/Tabs/Dashboard/AWDashboardSummaryTileViewController.m
+++ b/OSX/AppWage/UI/Tabs/Dashboard/AWDashboardSummaryTileViewController.m
@@ -95,6 +95,9 @@ upgradeSelectionRange: (BOOL) upgradeSelectionRange
     {
         return;
     }
+    
+    // Update the currency symbol to what is currently configured before formatting any numbers.
+    currencyFormatter.currencySymbol = [AWCurrencyHelper sharedInstance].currentCurrencySymbol;
 
     dispatch_async(dispatch_get_global_queue(0, 0), ^{
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/OSX/AppWage/UI/Tabs/Dashboard/AWSalesChart.m
+++ b/OSX/AppWage/UI/Tabs/Dashboard/AWSalesChart.m
@@ -140,6 +140,9 @@ static NSNumberFormatter * currencyFormatter;
         // Already locked. Exit.
         return;
     }
+    
+    // Update the currency symbol to what is currently configured before formatting any numbers.
+    currencyFormatter.currencySymbol = [AWCurrencyHelper sharedInstance].currentCurrencySymbol;
 
     dispatch_async(dispatch_get_global_queue(0, 0), ^{
         [self.delegate salesChartStartedLoading: self];


### PR DESCRIPTION
This should fix #14 and #21. I've tried to keep the fix as minimal as possible, without introducing a caching mechanism for the current currency symbol. It works fine here in my testing.