### PR TITLE
Fix Travis CI by compiling MailCore 2 via Carthage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: objective-c
 osx_image: xcode8
+before_script: cd OSX && carthage build && cd -
 script: xcodebuild clean build -workspace OSX/AppWage.xcworkspace -scheme AppWage


### PR DESCRIPTION
I've tried using MailCore 2 via CocoaPods, but even if I specify a recent Git Commit, CocoaPods doesn't apply this fix to the PodSpec:

https://github.com/MailCore/mailcore2/pull/1619

...and then the build fails because libcrypto is missing. So, `carthage build` it is.