### PR TITLE
Set minimum for date range selector

### DIFF
--- a/OSX/AppWage/UI/Popovers/DateRangeRankPopover/AWDateRangeSelectorViewController.m
+++ b/OSX/AppWage/UI/Popovers/DateRangeRankPopover/AWDateRangeSelectorViewController.m
@@ -336,6 +336,18 @@
         [previousYearMenuItem setHidden: YES];
     }
 
+    // Use AppStore launch day as minimum
+    NSDateComponents * components = [[NSDateComponents alloc] init];
+    [components setDay:10];
+    [components setMonth:7];
+    [components setYear:2010];
+    NSCalendar * gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    gregorian.timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
+    NSDate * minimum = [gregorian dateFromComponents:components];
+    [rangeDatePicker1 setMinDate:minimum];
+    [datePickerFrom setMinDate:minimum];
+    [datePickerTo setMinDate:minimum];
+    
     // Cannot pick past today
     [rangeDatePicker1 setMaxDate: [NSDate date]];
     [datePickerFrom setMaxDate: [NSDate date]];


### PR DESCRIPTION
There were no minimums initially set on the date range selector. By accident I selected the 6th century and the whole application locked up while it was trying to generate a graph starting from 6th century and going to present.

This change sets the minimum dates to the day the AppStore launched, July 10th, 2010, as there shouldn't be a need to go back further.